### PR TITLE
Patchfix for failing builds due to rate-limiting on OpenProcessing API

### DIFF
--- a/src/api/OpenProcessing.ts
+++ b/src/api/OpenProcessing.ts
@@ -43,6 +43,9 @@ export const getCurationSketches = async (
   const response = await fetch(
     `${openProcessingEndpoint}curation/${curationId}/sketches?${limitParam}`,
   );
+  if(!response.ok){
+    console.log('getCurationSketches', response.status, response.statusText)
+  }
   const payload = await response.json();
   return payload as OpenProcessingCurationResponse;
 };
@@ -78,6 +81,9 @@ export const getSketch = memoize(async (
   id: string,
 ): Promise<OpenProcessingSketchResponse> => {
   const response = await fetch(`${openProcessingEndpoint}sketch/${id}`);
+  if(!response.ok){
+    console.log('getSketch', id, response.status, response.statusText)
+  }
   const payload = await response.json();
   return payload as OpenProcessingSketchResponse;
 });

--- a/src/api/OpenProcessing.ts
+++ b/src/api/OpenProcessing.ts
@@ -36,7 +36,7 @@ export type OpenProcessingCurationResponse = Array<{
  * @param limit max number of sketches to return
  * @returns sketches
  */
-export const getCurationSketches = async (
+export const getCurationSketches = memoize(async (
   limit?: number,
 ): Promise<OpenProcessingCurationResponse> => {
   const limitParam = limit ? `limit=${limit}` : "";
@@ -44,11 +44,11 @@ export const getCurationSketches = async (
     `${openProcessingEndpoint}curation/${curationId}/sketches?${limitParam}`,
   );
   if(!response.ok){ //log error instead of throwing error to not cache result in memoize
-    console.log('getCurationSketches', response.status, response.statusText)
+    console.error('getCurationSketches', response.status, response.statusText)
   }
   const payload = await response.json();
   return payload as OpenProcessingCurationResponse;
-};
+});
 
 /**
  * API Response from a call to the Sketch endpoint
@@ -82,7 +82,7 @@ export const getSketch = memoize(async (
 ): Promise<OpenProcessingSketchResponse> => {
   const response = await fetch(`${openProcessingEndpoint}sketch/${id}`);
   if(!response.ok){ //log error instead of throwing error to not cache result in memoize
-    console.log('getSketch', id, response.status, response.statusText)
+    console.error('getSketch', id, response.status, response.statusText)
   }
   const payload = await response.json();
   return payload as OpenProcessingSketchResponse;
@@ -96,7 +96,7 @@ export const getSketchSize = memoize(async (id: string) => {
 
   const response = await fetch(`${openProcessingEndpoint}sketch/${id}/code`);
   if(!response.ok){ //log error instead of throwing error to not cache result in memoize
-    console.log('getSketchSize', id, response.status, response.statusText)
+    console.error('getSketchSize', id, response.status, response.statusText)
   }
   const payload = await response.json();
 

--- a/src/api/OpenProcessing.ts
+++ b/src/api/OpenProcessing.ts
@@ -43,7 +43,7 @@ export const getCurationSketches = async (
   const response = await fetch(
     `${openProcessingEndpoint}curation/${curationId}/sketches?${limitParam}`,
   );
-  if(!response.ok){
+  if(!response.ok){ //log error instead of throwing error to not cache result in memoize
     console.log('getCurationSketches', response.status, response.statusText)
   }
   const payload = await response.json();
@@ -81,7 +81,7 @@ export const getSketch = memoize(async (
   id: string,
 ): Promise<OpenProcessingSketchResponse> => {
   const response = await fetch(`${openProcessingEndpoint}sketch/${id}`);
-  if(!response.ok){
+  if(!response.ok){ //log error instead of throwing error to not cache result in memoize
     console.log('getSketch', id, response.status, response.statusText)
   }
   const payload = await response.json();
@@ -95,6 +95,9 @@ export const getSketchSize = memoize(async (id: string) => {
   }
 
   const response = await fetch(`${openProcessingEndpoint}sketch/${id}/code`);
+  if(!response.ok){ //log error instead of throwing error to not cache result in memoize
+    console.log('getSketchSize', id, response.status, response.statusText)
+  }
   const payload = await response.json();
 
   for (const tab of payload) {

--- a/src/layouts/SketchLayout.astro
+++ b/src/layouts/SketchLayout.astro
@@ -18,9 +18,10 @@ import { ScalingIframe } from "@components/ScalingIframe";
 interface Props {
   sketchId: string;
   authorName: string;
+  title: string;
 }
 
-const { sketchId, authorName } = Astro.props;
+const { sketchId, authorName, title } = Astro.props;
 const sketchInfo = await getSketch(sketchId);
 
 const currentLocale = getCurrentLocale(Astro.url.pathname);
@@ -46,46 +47,56 @@ if (width && height) {
   heightOverWidth = height / width;
 }
 
-const iframeTitle = `OpenProcessing Sketch: ${sketchInfo.title} by ${authorName}`;
+const iframeTitle = `OpenProcessing Sketch: ${title} by ${authorName}`;
 ---
 
 <Head
-  title={sketchInfo.title}
+  title={title}
   locale={currentLocale}
   featuredImageSrc={featuredImageURL}
   description={sketchInfo.instructions}
 />
 
 <BaseLayout
-  title={sketchInfo.title}
+  title={title}
   titleAuthor={authorName}
   subtitle={dateString}
   variant="item"
   topic={"community"}
 >
   <div class="max-w-[770px]">
-    <div style={{
-      position: 'relative',
-      width: '100%',
-      paddingBottom: `${(heightOverWidth * 100).toFixed(4)}%`,
-    }}>
-      {width ? (
-        <ScalingIframe
-          client:load
-          src={makeSketchEmbedUrl(sketchInfo.visualID)}
-          width={width}
-          height={height}
-          title={iframeTitle}
-        />
-      ) : (
-        <iframe
-          src={makeSketchEmbedUrl(sketchInfo.visualID)}
-          width="100%"
-          height="100%"
-          style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}
-          title={iframeTitle}
-        />
-      )}
+    <div
+      style={{
+        position: "relative",
+        width: "100%",
+        paddingBottom: `${(heightOverWidth * 100).toFixed(4)}%`,
+      }}
+    >
+      {
+        width ? (
+          <ScalingIframe
+            client:load
+            src={makeSketchEmbedUrl(sketchInfo.visualID)}
+            width={width}
+            height={height}
+            title={iframeTitle}
+          />
+        ) : (
+          <iframe
+            src={makeSketchEmbedUrl(sketchInfo.visualID)}
+            width="100%"
+            height="100%"
+            style={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+            }}
+            title={iframeTitle}
+          />
+        )
+      }
     </div>
     <div class="py-md grid gap-y-sm md:gap-y-md">
       <LinkButton

--- a/src/pages/[locale]/community.astro
+++ b/src/pages/[locale]/community.astro
@@ -5,7 +5,8 @@ import CommunityLayout from "@layouts/CommunityLayout.astro";
 import { getCollectionInLocaleWithFallbacks } from "@pages/_utils";
 
 export const getStaticPaths = async () => {
-  const sketches = await getCurationSketches(10);
+  const allSketches = await getCurationSketches();
+  const sketches = allSketches.slice(0, 10);
   return await Promise.all(
     nonDefaultSupportedLocales.map(async (locale) => {
       const libraries = await getCollectionInLocaleWithFallbacks(

--- a/src/pages/[locale]/sketches/[...slug].astro
+++ b/src/pages/[locale]/sketches/[...slug].astro
@@ -9,7 +9,7 @@ export async function getStaticPaths() {
     nonDefaultSupportedLocales.map(async (locale) => {
       return sketches.map((sketch) => ({
         params: { locale, slug: sketch.visualID },
-        props: { authorName: sketch.fullname },
+        props: { authorName: sketch.fullname, title: sketch.title },
       }));
     })
   );
@@ -17,7 +17,7 @@ export async function getStaticPaths() {
   return entries.flat();
 }
 const { slug } = Astro.params;
-const { authorName } = Astro.props;
+const { authorName, title } = Astro.props;
 ---
 
-<SketchLayout sketchId={slug} authorName={authorName} />
+<SketchLayout sketchId={slug} authorName={authorName} title={title} />

--- a/src/pages/community.astro
+++ b/src/pages/community.astro
@@ -3,7 +3,8 @@ import { getCurationSketches } from "../api/OpenProcessing";
 import CommunityLayout from "../layouts/CommunityLayout.astro";
 import { getCollectionInDefaultLocale } from "./_utils";
 
-const sketches = await getCurationSketches(10);
+const allSketches = await getCurationSketches(10);
+const sketches = allSketches.slice(0, 10);
 const libraries = await getCollectionInDefaultLocale("libraries");
 const pastEvents = await getCollectionInDefaultLocale("events");
 ---

--- a/src/pages/sketches/[...slug].astro
+++ b/src/pages/sketches/[...slug].astro
@@ -6,12 +6,12 @@ export async function getStaticPaths() {
   const sketches = await getCurationSketches();
   return sketches.map((sketch) => ({
     params: { slug: sketch.visualID },
-    props: { authorName: sketch.fullname },
+    props: { authorName: sketch.fullname, title: sketch.title },
   }));
 }
 
 const { slug } = Astro.params;
-const { authorName } = Astro.props;
+const { authorName, title } = Astro.props;
 ---
 
-<SketchLayout sketchId={slug} authorName={authorName} />
+<SketchLayout sketchId={slug} authorName={authorName} title={title} />


### PR DESCRIPTION
Relates to [issue #831](https://github.com/processing/p5.js-website/issues/831)

This is a patchfix solution for the above issue, but as can be seen below, we will still hit rate-limits on some sketches, so **it may be best to copy 831 to the OpenProcessing API repo maintainers**.

## Changes:
- Add error handling for data-fetching methods for visibility
  - `console.error` instead of throwing error, so that the error result is not memoized. 
- Update `SketchLayout` to get `title` from props instead of from `getSketch`
  - `title` is already in the data from `getCurationSketches` for each item, and `getSketch` sometimes fails due to rate limiting
- Update `getCurationSketches` to be memoized
- Update the community page to get the first 10 sketches in the curation by slicing the memoized result from `getCurationSketches` instead of using `getCurationSketches(10)` which will call the API again.


## Notes:
These changes result in `test/build` passing, however since we can see in the call stack below that we still hit rate limits on the final 19 sketch pages. The second screenshot shows what the built page looks like. 

<img width="1247" alt="Screenshot 2025-05-05 at 14 01 09" src="https://github.com/user-attachments/assets/74a452db-79c4-4802-8d4f-5e0289bba35f" />

<img width="1230" alt="Screenshot 2025-05-05 at 13 29 13" src="https://github.com/user-attachments/assets/27bf1ab2-712c-4b3c-a7e7-2e28465cba8f" />


## Proposed Solution 1:
Increase the limit in OpenProcessing API for builds by **25 hits/10 minutes**.

## Proposed Solution 2:
- Update the OpenProcessing API's `getCurationSketches` endpoint to return the below additional properties returned by `getSketch` for each item

```
  instructions: string;
  license: string;
  createdOn: string;
  mode: string;
```
- Refactor `SketchLayout` to take the properties above as props similar to the [changes here to move `title` to props](https://github.com/clairep94/p5.js-website/pull/2/commits/03093c48e9020d107845d313f8cd310d26c594d9), or refactor `getSketch` to:
```
export const getSketch = memoize(async (id: string):  => {
  const sketches = await getCurationSketches();
  if (!sketches) return undefined;
  
  const result = sketches.find((el) => el.visualID === id);
  return result as OpenProcessingSketchResponse;
});
```

- This would result in no longer needing to hit `/sketch/$id` for each curated sketch, greatly reducing the number of calls in a build.